### PR TITLE
Add logging and IP info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ python main.py
 ```
 
 At the end of the run the file `snappfood_vendor_products.xlsx` will be created
-with all collected product data.
+with all collected product data. All console output is also written to
+`crawler.log` for later review.


### PR DESCRIPTION
## Summary
- log all output to both console and `crawler.log`
- show which IP address is used for each request attempt
- convert print statements to logging
- mention log file in README

## Testing
- `python -m py_compile main.py headers.py my_ip.py`

------
https://chatgpt.com/codex/tasks/task_b_6887188791748330bec9819f046f8310